### PR TITLE
fix: 토큰 저장방식 session, cookie로 나누어서 저장하게 변경

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -16,19 +16,20 @@ import NaverLoginHandler from "./components/menu/login/NaverLoginHandler";
 import React from "react";
 import Timer from "./page/menu/Timer";
 import KanbanInvite from "./components/menu/kanban/KanbanInvite";
+import { getCookie } from "./components/menu/login/utils/cookie";
 
 function App() {
   const NavStatus = useSelector((state) => state.commonSlice.openNav);
 
   //로그인이 되어있지 않는 경우 메인화면으로 돌아가게함.
   function RequireAuth({ children, redirectTo }) {
-    const token = localStorage.getItem("token");
+    const token = getCookie("cocoriLogin");
     return token ? children : <Navigate to={redirectTo} />;
   }
 
   //로그인이 되어있는 경우
   function RejectAuth({ children, redirectTo }) {
-    const token = localStorage.getItem("token");
+    const token = getCookie("cocoriLogin");
     return !token ? children : <Navigate to={redirectTo} />;
   }
 

--- a/src/components/layout/Nav/Header.jsx
+++ b/src/components/layout/Nav/Header.jsx
@@ -6,22 +6,22 @@ import styles from "../styles/_Header.module.scss";
 import { setOpenLoginReducer } from "../../../redux/Slice/commonSlice";
 
 import AfterLogin from "./Navbar/AfterLogin";
+import { getCookie } from "../../menu/login/utils/cookie";
 
 const Header = ({ isOpen, toggleOpen }) => {
   const dispatch = useDispatch();
 
-  const userInfo = useSelector((state) => state.userSlice.userInfo);
   const openLoginModal = () => {
     dispatch(setOpenLoginReducer(true));
   };
-  const token = localStorage.getItem("token");
+  const token = getCookie("cocoriLogin");
   //로그인 정보 불러오기 토큰이 없을 경우 api에서 인증이 안됐다고 떠서 if에다가 토큰이 있을 경우에만 실행하게 바꾸어줌.
   useEffect(() => {
     if (token) {
       dispatch(setOpenLoginReducer());
       dispatch(getUserInfo());
     }
-  }, [dispatch, getUserInfo]);
+  }, [getUserInfo]);
 
   return (
     <nav className={styles.header}>

--- a/src/components/layout/Nav/Navbar/AfterLogin.js
+++ b/src/components/layout/Nav/Navbar/AfterLogin.js
@@ -5,13 +5,17 @@ import { MenuToggle } from "./MenuToggle";
 import { Icon } from "@iconify/react";
 import styles from "../Style/_AfterLogin.module.scss";
 import { useDimensions } from "../../../../hooks/useDemenstions";
+import { useCookies } from "react-cookie";
 
 const AfterLogin = ({ isOpen, toggleOpen }) => {
   const containerRef = useRef(null);
   const { height } = useDimensions(containerRef);
 
+  //쿠키정의, 재정의, 쿠키제거를 한번에 넣어주지 않으면 제거가 되지 않아서 모두다 넣어줌.
+  const [cookies, setCookie, removeCookie] = useCookies(["cocoriLogin"]);
   const logoutHandler = () => {
-    localStorage.removeItem("token");
+    sessionStorage.removeItem("token");
+    removeCookie("cocoriLogin", { path: "/" });
     window.location.replace("/");
   };
   // const navHandler = () => {

--- a/src/components/layout/Nav/Navbar/Navigation.js
+++ b/src/components/layout/Nav/Navbar/Navigation.js
@@ -4,7 +4,7 @@ import "../Style/_Navbar.scss";
 import { MenuItem } from "./MenuItem";
 import CocoriLogo from "../../../../static/image/cocoli_white.png";
 import { useNavigate } from "react-router-dom";
-import { useSelector } from "react-redux";
+import { shallowEqual, useSelector } from "react-redux";
 
 const variants = {
   open: {
@@ -17,8 +17,11 @@ const variants = {
 
 const Navigation = ({ isOpen, toggleOpen }) => {
   const navigate = useNavigate();
-  const userInfo = useSelector((state) => state.userSlice.userInfo);
-  console.log(userInfo);
+  const userInfo = useSelector(
+    (state) => state.userSlice.userInfo,
+    shallowEqual
+  );
+
   return (
     <>
       {toggleOpen && isOpen && (

--- a/src/components/menu/login/NaverLoginHandler.js
+++ b/src/components/menu/login/NaverLoginHandler.js
@@ -5,8 +5,6 @@ import { authLogin } from "../../../redux/Async/user";
 const NaverLoginHandler = () => {
   const code = new URL(window.location.href).searchParams.get("code");
   const dispatch = useDispatch();
-  console.log(code);
-  console.log("여기서 에러나는거지?");
   useEffect(() => {
     dispatch(
       authLogin({

--- a/src/components/menu/login/utils/cookie.js
+++ b/src/components/menu/login/utils/cookie.js
@@ -1,0 +1,11 @@
+import { Cookies } from "react-cookie";
+
+const cookies = new Cookies();
+
+export const setCookie = (name, value, option) => {
+  return cookies.set(name, value, { ...option });
+};
+
+export const getCookie = (name) => {
+  return cookies.get(name);
+};

--- a/src/index.js
+++ b/src/index.js
@@ -7,13 +7,16 @@ import store from "./redux/store";
 import "./index.scss";
 import { PersistGate } from "redux-persist/integration/react";
 import { persistStore } from "redux-persist";
+import { CookiesProvider } from "react-cookie";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 let persistor = persistStore(store);
 root.render(
   <Provider store={store}>
     <PersistGate loading={null} persistor={persistor}>
+      {/*<CookiesProvider>*/}
       <App />
+      {/*</CookiesProvider>*/}
     </PersistGate>
   </Provider>
 );

--- a/src/redux/Slice/userSlice.js
+++ b/src/redux/Slice/userSlice.js
@@ -1,6 +1,7 @@
 import { createSlice } from "@reduxjs/toolkit";
 import { getUserInfo, authLogin, changeUserInfo } from "../Async/user";
 import { useNavigate } from "react-router-dom";
+import { setCookie } from "../../components/menu/login/utils/cookie";
 
 const UserSlice = createSlice({
   name: "user",
@@ -16,10 +17,17 @@ const UserSlice = createSlice({
       })
       .addCase(authLogin.pending, (state, action) => {})
       .addCase(authLogin.fulfilled, (state, action) => {
-        localStorage.setItem(
-          "token",
-          JSON.stringify(action.payload, ["accessToken", "refreshToken"])
-        );
+        const refreshToken = action.payload.refreshToken;
+        const accessToken = action.payload.accessToken;
+        const expires = new Date();
+        expires.setDate(expires.getDate() + 14);
+        setCookie("cocoriLogin", refreshToken, {
+          path: "/",
+          secure: true,
+          expires,
+        });
+
+        sessionStorage.setItem("token", JSON.stringify(accessToken));
         window.location.replace("/");
       })
       .addCase(changeUserInfo.pending, (state, action) => {


### PR DESCRIPTION
2022.06.04.

accesstoken은 session에 
refreshtoken은 cookie에 저장하게 변경함. 
token은 axios interceptors를 사용해 기존의 방법과 같게 accesstoken이 만료되면 다시 refreshtoken을 발급받게 구성함.